### PR TITLE
Fix 'change_EOC_time' malfunction when reactive_experiments recognized as non-reactive_experiments

### DIFF
--- a/uconnrcmpy/conditions.py
+++ b/uconnrcmpy/conditions.py
@@ -347,11 +347,10 @@ class Condition(object):
             if str(experiment) in self.reactive_experiments:
                 experiment = self.reactive_experiments[str(experiment)]
             elif str(experiment) in self.nonreactive_experiments:
-                exp = Experiment(experiment, cti_file=self.cti_file)
-                self.reactive_experiments[exp.file_path.name] = exp
+                experiment = Experiment(experiment, cti_file=self.cti_file)
+                self.reactive_experiments[experiment.file_path.name] = experiment
                 if self.plotting:
-                    self.plot_reactive_figures(exp)
-                experiment = self.reactive_experiments[str(experiment)]
+                    self.plot_reactive_figures(experiment)
             else:
                 raise ValueError('{} could not be found in the Condition. '
                                  'Did you add it with add_experiment?'.format(str(experiment)))

--- a/uconnrcmpy/conditions.py
+++ b/uconnrcmpy/conditions.py
@@ -347,7 +347,11 @@ class Condition(object):
             if str(experiment) in self.reactive_experiments:
                 experiment = self.reactive_experiments[str(experiment)]
             elif str(experiment) in self.nonreactive_experiments:
-                experiment = self.nonreactive_experiments[str(experiment)]
+                exp = Experiment(experiment, cti_file=self.cti_file)
+                self.reactive_experiments[exp.file_path.name] = exp
+                if self.plotting:
+                    self.plot_reactive_figures(exp)
+                experiment = self.reactive_experiments[str(experiment)]
             else:
                 raise ValueError('{} could not be found in the Condition. '
                                  'Did you add it with add_experiment?'.format(str(experiment)))

--- a/uconnrcmpy/traces.py
+++ b/uconnrcmpy/traces.py
@@ -292,9 +292,12 @@ class ExperimentalPressureTrace(object):
         """
         offset = int(round(time/1000*self.frequency, 0))
         self.EOC_idx += offset
-        self.p_EOC = self.pressure[self.EOC_idx]
-        self.is_reactive = is_reactive
-        self.zeroed_time = self.time - self.time[self.EOC_idx]
+        if self.EOC_idx <= 0:
+            raise ValueError('EOC index out of range, please check the EOC time on the plot')
+        else:
+            self.p_EOC = self.pressure[self.EOC_idx]
+            self.is_reactive = is_reactive
+            self.zeroed_time = self.time - self.time[self.EOC_idx]
 
     def find_EOC(self):
         """Find the index and pressure at the end of compression.

--- a/uconnrcmpy/traces.py
+++ b/uconnrcmpy/traces.py
@@ -292,7 +292,7 @@ class ExperimentalPressureTrace(object):
         """
         offset = int(round(time/1000*self.frequency, 0))
         self.EOC_idx += offset
-        if self.EOC_idx <= 0:
+        if self.EOC_idx <= 0 or self.EOC_idx >= len(self.pressure):
             raise ValueError('EOC index out of range, please check the EOC time on the plot')
         else:
             self.p_EOC = self.pressure[self.EOC_idx]


### PR DESCRIPTION
(1)Add the misrecongnized "non-reactive experiment" back to
reactive_experiment list. Also creat a reactive-case plot instead of a
nonreactive-case plot for further modification.
(2)Add the error message when EOC_index out of range.